### PR TITLE
change generated file layout

### DIFF
--- a/static/converter.js
+++ b/static/converter.js
@@ -109,7 +109,7 @@ function generatePayloads({ sketchDir }, sourceOptions) {
 #define STATIC_FILES_H_
 
 #pragma once
-#include <aWOT.h>
+#include "aWOT.h"
 using namespace awot;
 namespace AwotPages{
   /*generated source

--- a/static/converter.js
+++ b/static/converter.js
@@ -107,10 +107,10 @@ function generatePayloads({ sketchDir }, sourceOptions) {
   const destinationCpp = path.join(sketchDir, 'AwotPages.cpp');
   const contentHeader = `#ifndef STATIC_FILES_H_
 #define STATIC_FILES_H_
-
-#pragma once
 #include "aWOT.h"
+
 using namespace awot;
+
 namespace AwotPages{
   /*generated source
   static class AwotPages{
@@ -125,8 +125,8 @@ namespace AwotPages{
   const contentCpp = `#ifndef STATIC_FILES_CPP_
   #define STATIC_FILES_CPP_
   
-  #pragma once
   #include "AwotPages.h"
+  
   using namespace AwotPages;
   using namespace awot;
 


### PR DESCRIPTION
Hi,
Platformio keeps yelling at the single StaticFiles.h (even though it compiles in arduino IDE)

So I propose this file layout for the generator
--AwotPages.h
  namespace AwotPages, router config included
--AwotPages.cpp
  generated implementation 


usage example:

```cpp
#include "AwotPages.h"
using namespace AwotPages;
// ...

void commanderSetup(Application &app){
  app.get("/pin", &setPin);
  app.get("/pins", &getPins);
  app.use(AwotPages::staticFilesConfig());
}```


**note:**
I only tested if it compiles. I didn't adapt convert_test.js.
If you're inclined to accept my proposal I can adapt the test too ....

Cheers !!